### PR TITLE
Update ydlidar_node.cpp; change scan_msg settings

### DIFF
--- a/Chapter9_GoPiGo3_SLAM/ydlidar/src/ydlidar_node.cpp
+++ b/Chapter9_GoPiGo3_SLAM/ydlidar/src/ydlidar_node.cpp
@@ -131,8 +131,8 @@ int main(int argc, char * argv[]) {
             scan_msg.angle_min = scan.config.min_angle;
             scan_msg.angle_max = scan.config.max_angle;
             scan_msg.angle_increment = scan.config.ang_increment;
-            scan_msg.scan_time = scan.config.scan_time;
-            scan_msg.time_increment = scan.config.time_increment;
+            scan_msg.scan_time = 1/_frequency;
+            scan_msg.time_increment = 1/((float)samp_rate*1000);
             scan_msg.range_min = scan.config.min_range;
             scan_msg.range_max = scan.config.max_range;
             


### PR DESCRIPTION
change scan_msg.scan_time and scan_msg.time_increment to fix issue with LaserScan not showing in RVIZ when the global_frame is /map. 
References:
https://answers.ros.org/question/10284/rviz-tf-error-unknown-reason-for-transform-failure/
https://github.com/EAIBOT/ydlidar/pull/19/files